### PR TITLE
workaround for leafmap bug

### DIFF
--- a/notebooks/actinia_Klassifikation.ipynb
+++ b/notebooks/actinia_Klassifikation.ipynb
@@ -75,7 +75,9 @@
     "\n",
     "Wir nutzen [Leafmap](https://leafmap.org) um die Ergebnisse von actinia zu visualisieren. Leafmap ist ein Python-Paket für interaktives Mapping und raumbezogene Analysen mit minimalem Programmieraufwand in einer Jupyter-Umgebung (siehe auch: [actinia with leafmap notebook](https://github.com/actinia-org/actinia-python-client/blob/main/notebooks/actinia_leafmap.ipynb)).\n",
     "\n",
-    "Als weiteres Paket installieren wir den Python Client Library für actinia ([actinia-python-client](https://github.com/actinia-org/actinia-python-client/))."
+    "Als weiteres Paket installieren wir den Python Client Library für actinia ([actinia-python-client](https://github.com/actinia-org/actinia-python-client/)).\n",
+    "\n",
+    "**Wichtig:** Danach müssen wir uns einmal ausloggen (im Menü File -> Log Out) und wieder einloggen."
    ]
   },
   {
@@ -87,6 +89,31 @@
    "source": [
     "!pip install -U leafmap\n",
     "!pip install actinia-python-client==0.4.1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "37d1d50d-f7d1-4248-b0d7-67ab87b5c51c",
+   "metadata": {},
+   "source": [
+    "Bitte einmal ausloggen (im Menü File -> Log Out) und wieder einloggen."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "88f19cfa-ac45-40d4-83e9-c37369052d1c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "# '/home/jovyan/.local/bin'\n",
+    "path = os.getenv(\"PATH\")\n",
+    "path = path + os.pathsep + \"/home/jovyan/.local/bin\"\n",
+    "os.environ[\"PATH\"] = path\n",
+    "# adjust PYTHONPATH\n",
+    "import sys\n",
+    "sys.path.append(\"/home/jovyan/.local/lib/python3.11/site-packages\")"
    ]
   },
   {
@@ -1326,7 +1353,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.11.6"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {


### PR DESCRIPTION
Direkt nach der Installation von leafmap muss man sich einmal ausloggen und wieder einloggen, dann funktioniert leafmap. Nur den jupyterlab kernel neu zu starten reicht leider nicht. Ein entsprechender Hinweis vor und nach der Zelle mit der leafmap Installation wurde hinzugefügt.